### PR TITLE
Fix pyvenv_name to handle spaces.

### DIFF
--- a/.bash.d/.bash_ps1
+++ b/.bash.d/.bash_ps1
@@ -100,7 +100,7 @@ function get_venv_name() {
   local pyvenv_cfg="${venv_root}/pyvenv.cfg"
   
   if [[ -f "${pyvenv_cfg}" ]]; then
-    venv_name=$(awk -F= '/^name=/ {print $2}' "${pyvenv_cfg}")
+    venv_name=$(awk -F= '/^name[[:space:]]*=/ {print $2}' "${pyvenv_cfg}"
   fi
 
   if [[ -z "${venv_name}" && -f "${venv_root}/venv_name.txt" ]]; then


### PR DESCRIPTION
This finishes the venv_name fix to allow the names to be stored in pyvenv.cfg instead of a separate venv_name.txt file.