### PR TITLE
Fix check for venv when inactive

### DIFF
--- a/.bash.d/.bash_ps1
+++ b/.bash.d/.bash_ps1
@@ -89,7 +89,7 @@ function get_venv_name() {
   local pyvenv_cfg="${venv_root}/pyvenv.cfg"
   
   if [[ -f "${pyvenv_cfg}" ]]; then
-    venv_name=$(awk -F= '/^name[[:space:]]*=/ {print $2}' "${pyvenv_cfg}"
+    venv_name=$(awk -F= '/^name[[:space:]]*=/ {print $2}' "${pyvenv_cfg}")
   fi
 
   if [[ -z "${venv_name}" && -f "${venv_root}/venv_name.txt" ]]; then
@@ -120,7 +120,7 @@ function parse_venv() {
     local venv_root="$(get_venv_root)"
     local git_root="$(git rev-parse --show-toplevel 2>/dev/null)"
     # Add ending / to git_root and check for match variable substitution removing the leading /
-    if [[ -n "$git_root" && "${venv_root#$git_root/}" == /* ]]; then
+    if [[ -n "$git_root" && "${venv_root#$git_root/}" != /* ]]; then
       echo -e "*$(get_venv_name)*" # venv is in repo but inactive
     else
       echo -e "+$(get_venv_name)+" # venv is in parents but inactive

--- a/.bash.d/.bash_ps1
+++ b/.bash.d/.bash_ps1
@@ -117,7 +117,10 @@ function parse_venv() {
       echo -e "-${active_name}-" # venv active but not in repo or parents
     fi
   elif [[ -n "${venv_name}" ]]; then
-    if [[ -n "$(parse_git_branch)" ]]; then
+    local venv_root="$(get_venv_root)"
+    local git_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+    # Add ending / to git_root and check for match variable substitution removing the leading /
+    if [[ -n "$git_root" && "${venv_root#$git_root/}" == /* ]]; then
       echo -e "*$(get_venv_name)*" # venv is in repo but inactive
     else
       echo -e "+$(get_venv_name)+" # venv is in parents but inactive


### PR DESCRIPTION
Change venv inactive check to show when the venv is in the current repo or a parent.