### PR TITLE
Refactor .bash_paths to use idempotent PATH additions

### DIFF
--- a/.bash.d/.bash_paths
+++ b/.bash.d/.bash_paths
@@ -2,15 +2,16 @@
 # Sourced from .bashrc before the non-interactive guard
 # Interactive-only setup (completions, shell hooks) is in .bash_env
 
-# Prevent double-sourcing (the .bash.d loop may pick this up again)
-if [[ -n "$_BASH_PATHS_SOURCED" ]]; then
-    return 0 2>/dev/null || exit 0
-fi
-_BASH_PATHS_SOURCED=1
+# Prepend to PATH only if not already present
+_prepend_path() {
+    if [[ ":$PATH:" != *":$1:"* ]]; then
+        export PATH="$1:$PATH"
+    fi
+}
 
 # Setup PERL5 environment variables
 if [ -d "$HOME/perl5" ]; then
-    export PATH="$HOME/perl5/bin${PATH:+:${PATH}}"
+    _prepend_path "$HOME/perl5/bin"
     export PERL5LIB="$HOME/perl5/lib/perl5${PERL5LIB:+:${PERL5LIB}}"
     export PERL_LOCAL_LIB_ROOT="$HOME/perl5${PERL_LOCAL_LIB_ROOT:+:${PERL_LOCAL_LIB_ROOT}}"
     export PERL_MB_OPT="--install_base \"$HOME/perl5\""
@@ -26,21 +27,21 @@ export NVM_DIR="$HOME/.nvm"
 if [ -s "$NVM_DIR/alias/default" ]; then
     _nvm_ver=$(< "$NVM_DIR/alias/default")
     _nvm_path=$(ls -d "$NVM_DIR/versions/node/v${_nvm_ver}"* 2>/dev/null | sort -V | tail -1)
-    [ -n "$_nvm_path" ] && export PATH="$_nvm_path/bin:$PATH"
+    [ -n "$_nvm_path" ] && _prepend_path "$_nvm_path/bin"
     unset _nvm_ver _nvm_path
 fi
 
 # pyenv - add shims to PATH for all shells
 export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+_prepend_path "$PYENV_ROOT/shims"
+_prepend_path "$PYENV_ROOT/bin"
 
 # mise - ensure binary and shims are on PATH for all shells
 export MISE_PATH="$HOME/.local/bin/mise"
 if [ -x "$MISE_PATH" ]; then
-    export PATH="$(dirname "$MISE_PATH"):$HOME/.local/share/mise/shims:$PATH"
-else
-    export PATH="$HOME/.local/share/mise/shims:$PATH"
+    _prepend_path "$(dirname "$MISE_PATH")"
 fi
+_prepend_path "$HOME/.local/share/mise/shims"
 
 # Change uv venv directory to not clobber existing .venv
 export UV_VENV_DIR=.venv/uv-venv

--- a/.bash.d/.bash_paths
+++ b/.bash.d/.bash_paths
@@ -27,7 +27,9 @@ export NVM_DIR="$HOME/.nvm"
 if [ -s "$NVM_DIR/alias/default" ]; then
     _nvm_ver=$(< "$NVM_DIR/alias/default")
     _nvm_path=$(ls -d "$NVM_DIR/versions/node/v${_nvm_ver}"* 2>/dev/null | sort -V | tail -1)
-    [ -n "$_nvm_path" ] && _prepend_path "$_nvm_path/bin"
+    if [ -n "$_nvm_path" ]; then
+        _prepend_path "$_nvm_path/bin"
+    fi
     unset _nvm_ver _nvm_path
 fi
 
@@ -38,10 +40,10 @@ _prepend_path "$PYENV_ROOT/bin"
 
 # mise - ensure binary and shims are on PATH for all shells
 export MISE_PATH="$HOME/.local/bin/mise"
+_prepend_path "$HOME/.local/share/mise/shims"
 if [ -x "$MISE_PATH" ]; then
     _prepend_path "$(dirname "$MISE_PATH")"
 fi
-_prepend_path "$HOME/.local/share/mise/shims"
 
 # Change uv venv directory to not clobber existing .venv
 export UV_VENV_DIR=.venv/uv-venv

--- a/.bash_init
+++ b/.bash_init
@@ -14,11 +14,11 @@ _dir="$PWD"
 while [[ "$_dir" != "/" ]]; do
     if [[ -d "$_dir/.venv/uv-venv/bin" ]]; then
         export VIRTUAL_ENV="$_dir/.venv/uv-venv"
-        export PATH="$VIRTUAL_ENV/bin:$PATH"
+        _prepend_path "$VIRTUAL_ENV/bin"
         break
     elif [[ -d "$_dir/.venv/bin" ]]; then
         export VIRTUAL_ENV="$_dir/.venv"
-        export PATH="$VIRTUAL_ENV/bin:$PATH"
+        _prepend_path "$VIRTUAL_ENV/bin"
         break
     fi
     _dir=$(dirname "$_dir")


### PR DESCRIPTION
## Summary

- Replace `_BASH_PATHS_SOURCED` double-source guard with `_prepend_path` helper that checks PATH membership before prepending
- Uses `if/then/fi` instead of `[[ ]] &&` pattern to avoid spurious exit code 1 under `set -e`
- Update `.bash_init` venv activation to use the same helper

## Context

When `.bash_paths` is sourced multiple times (e.g. via both `.bashrc` and `BASH_ENV`), PATH entries were duplicated. The old guard variable approach was fragile — if ever exported, child shells would skip PATH setup entirely.

The new approach is idempotent: safe to source any number of times with no duplication and no side effects.

Closes #41

## Test plan

- [ ] Source `.bash_paths` multiple times, verify PATH entry count stays constant
- [ ] Run with `set -e` active, confirm no unexpected exits
- [ ] Verify all tools (`mise`, `uv`, `pytest`, `ruff`) resolve correctly
- [ ] Copy to home directory, open new shell, confirm PATH is clean